### PR TITLE
Add XO code style to alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ For the most part, using ESLint is as simple as tweaking a configuration file in
 
 - [Standard](https://github.com/standard/standard)
 - [JSHint](http://jshint.com/)
+- [XO](https://github.com/xojs/xo)
 
 ## Linting CSS - stylelint
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ For the most part, using ESLint is as simple as tweaking a configuration file in
 
 #### Alternatives
 
-- [Standard](https://github.com/feross/standard)
+- [Standard](https://github.com/standard/standard)
 - [JSHint](http://jshint.com/)
 
 ## Linting CSS - stylelint


### PR DESCRIPTION
### Changes

- Update StandardJS link
- Add [XO code style](https://github.com/xojs/xo) to alternatives
